### PR TITLE
[Docs] Visualization of the annofilter-junctions project

### DIFF
--- a/.codeboarding/CLI_and_Configuration_Manager.md
+++ b/.codeboarding/CLI_and_Configuration_Manager.md
@@ -1,0 +1,43 @@
+```mermaid
+
+graph LR
+
+    CLI_and_Configuration_Manager["CLI and Configuration Manager"]
+
+    CLI_and_Configuration_Manager -- "Provides Configuration To" --> Main_Application_Orchestrator
+
+    click CLI_and_Configuration_Manager href "https://github.com/pfizer-opensource/annofilter-junctions/blob/main/.codeboarding//CLI_and_Configuration_Manager.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `CLI and Configuration Manager` component is crucial for the `Bioinformatics Data Processing Tool` as it serves as the primary interface for user interaction, enabling the tool to receive and validate all necessary execution parameters. This component is fundamental because it ensures that the subsequent data processing steps operate with correct and complete inputs, preventing errors and ensuring the integrity of the analysis.
+
+
+
+### CLI and Configuration Manager [[Expand]](./CLI_and_Configuration_Manager.md)
+
+This component is responsible for defining, parsing, and validating command-line arguments provided by the user. It sets up the initial execution parameters for the entire workflow, ensuring that all necessary inputs (file paths, filtering thresholds, annotation options) are correctly received and validated before the main processing begins. It acts as the primary interface for users to interact with the tool.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/GTF_Data_Processor.md
+++ b/.codeboarding/GTF_Data_Processor.md
@@ -1,0 +1,93 @@
+```mermaid
+
+graph LR
+
+    GTF_Data_Processor["GTF Data Processor"]
+
+    Main_Application_Orchestrator["Main Application Orchestrator"]
+
+    Junction_Annotation_Logic["Junction Annotation Logic"]
+
+    Main_Application_Orchestrator -- "utilizes" --> GTF_Data_Processor
+
+    GTF_Data_Processor -- "provides data to" --> Junction_Annotation_Logic
+
+    Junction_Annotation_Logic -- "queries data from" --> GTF_Data_Processor
+
+    click GTF_Data_Processor href "https://github.com/pfizer-opensource/annofilter-junctions/blob/main/.codeboarding//GTF_Data_Processor.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Overview of the GTF Data Processor component within the annofilter-junctions tool, detailing its purpose, internal structure, and interactions with other components.
+
+
+
+### GTF Data Processor [[Expand]](./GTF_Data_Processor.md)
+
+Defines data structures for genomic features (genes, transcripts, exons) and contains the logic to parse GTF files into these structured models. It builds and provides the necessary transcriptome context for junction annotation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `GtfFeature` (1:1)
+
+- `Gene` (1:1)
+
+- `Transcript` (1:1)
+
+- `Exon` (1:1)
+
+- `parse_gtf_attributes` (1:1)
+
+- `parse_gtf_row` (1:1)
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/transcriptome.py#L475-L596" target="_blank" rel="noopener noreferrer">`Transcriptome` (475:596)</a>
+
+
+
+
+
+### Main Application Orchestrator
+
+The main script or orchestrator component that initiates the GTF parsing process.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Junction Annotation Logic
+
+Queries the structured transcriptome data from GTF Data Processor to determine the annotation status of input junctions.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/General_Utilities.md
+++ b/.codeboarding/General_Utilities.md
@@ -1,0 +1,61 @@
+```mermaid
+
+graph LR
+
+    General_Utilities["General Utilities"]
+
+    Main_Application -- "utilizes" --> General_Utilities
+
+    Junction_Annotation_Logic -- "utilizes" --> General_Utilities
+
+    Junction_Filtering_Logic -- "utilizes" --> General_Utilities
+
+    click General_Utilities href "https://github.com/pfizer-opensource/annofilter-junctions/blob/main/.codeboarding//General_Utilities.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `General Utilities` component is fundamental because it provides essential, reusable helper functions that support various core operations across the bioinformatics data processing tool. These functions are designed to be generic and do not contain domain-specific annotation or filtering logic, making them highly modular and maintainable. By centralizing these common tasks, the component reduces code duplication and improves the overall efficiency and readability of the codebase.
+
+
+
+### General Utilities [[Expand]](./General_Utilities.md)
+
+Provides common helper functions for tasks such as coordinate calculations, string manipulation, and data formatting, which are reusable across different core components. These utilities are crucial for standardizing data representation and facilitating efficient data processing throughout the pipeline.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/annofilter_junctions.py#L18-L22" target="_blank" rel="noopener noreferrer">`annofilter_junctions.py:parse_bed12_row` (18:22)</a>
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/annofilter_junctions.py#L24-L37" target="_blank" rel="noopener noreferrer">`annofilter_junctions.py:group_bed_by_name` (24:37)</a>
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/annofilter_junctions.py#L39-L50" target="_blank" rel="noopener noreferrer">`annofilter_junctions.py:get_junction_id` (39:50)</a>
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/annofilter_junctions.py#L52-L67" target="_blank" rel="noopener noreferrer">`annofilter_junctions.py:get_donor_id` (52:67)</a>
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/annofilter_junctions.py#L69-L84" target="_blank" rel="noopener noreferrer">`annofilter_junctions.py:get_acceptor_id` (69:84)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Junction_Data_Processor.md
+++ b/.codeboarding/Junction_Data_Processor.md
@@ -1,0 +1,165 @@
+```mermaid
+
+graph LR
+
+    Main_CLI_Orchestrator["Main CLI & Orchestrator"]
+
+    Junction_Data_Processor["Junction Data Processor"]
+
+    Transcriptome_Data_Handler["Transcriptome Data Handler"]
+
+    Junction_Annotation_Engine["Junction Annotation Engine"]
+
+    Junction_Filtering_Engine["Junction Filtering Engine"]
+
+    Input_Output_I_O_Utility["Input/Output (I/O) Utility"]
+
+    Main_CLI_Orchestrator -- "orchestrates" --> Junction_Data_Processor
+
+    Main_CLI_Orchestrator -- "orchestrates" --> Transcriptome_Data_Handler
+
+    Input_Output_I_O_Utility -- "reads from" --> Main_CLI_Orchestrator
+
+    Junction_Data_Processor -- "provides structured data to" --> Junction_Annotation_Engine
+
+    Junction_Annotation_Engine -- "queries" --> Transcriptome_Data_Handler
+
+    Junction_Annotation_Engine -- "provides annotated data to" --> Junction_Filtering_Engine
+
+    Junction_Filtering_Engine -- "provides filtered data to" --> Input_Output_I_O_Utility
+
+    Input_Output_I_O_Utility -- "writes to" --> Main_CLI_Orchestrator
+
+    click Junction_Data_Processor href "https://github.com/pfizer-opensource/annofilter-junctions/blob/main/.codeboarding//Junction_Data_Processor.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This Bioinformatics Data Processing Tool is designed for handling RNA-seq junction data, transforming raw BED-formatted input into a structured and usable format for subsequent annotation and filtering. It processes raw data, annotates junctions against genomic features, and filters them based on various criteria, providing a refined dataset for downstream analysis.
+
+
+
+### Main CLI & Orchestrator
+
+This is the primary entry point of the application, responsible for parsing command-line arguments, orchestrating the overall workflow, and coordinating interactions between other components. It sets up the input and output streams and initiates the data processing pipeline.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/annofilter_junctions.py#L1897-L1959" target="_blank" rel="noopener noreferrer">`annofilter_junctions.py:main` (1897:1959)</a>
+
+
+
+
+
+### Junction Data Processor [[Expand]](./Junction_Data_Processor.md)
+
+This component handles the parsing, modeling, and initial organization of RNA-seq junction data from BED files. It transforms raw text data into structured Python objects.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/annofilter_junctions.py#L18-L22" target="_blank" rel="noopener noreferrer">`annofilter_junctions.py:parse_bed12_row` (18:22)</a>
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/annofilter_junctions.py#L24-L37" target="_blank" rel="noopener noreferrer">`annofilter_junctions.py:group_bed_by_name` (24:37)</a>
+
+
+
+
+
+### Transcriptome Data Handler
+
+This component is responsible for loading, parsing, and providing access to transcriptome-related data, such as gene models from GTF/GFF files. It likely offers functionalities to query gene, transcript, and exon information, which is critical for annotating junctions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/transcriptome.py#L1-L2" target="_blank" rel="noopener noreferrer">`transcriptome.py` (1:2)</a>
+
+
+
+
+
+### Junction Annotation Engine
+
+This component applies various annotation rules to the processed junction data. It uses information provided by the `Transcriptome Data Handler` to determine if a junction is novel, known, exonic, intronic, or falls within specific genomic contexts.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/annofilter_junctions.py#L1-L2" target="_blank" rel="noopener noreferrer">`annofilter_junctions.py` (1:2)</a>
+
+
+
+
+
+### Junction Filtering Engine
+
+This component applies user-defined or pre-configured filtering criteria to the annotated junction data. It removes junctions that do not meet certain quality, abundance, or annotation-based thresholds, reducing noise and focusing on relevant events.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/annofilter_junctions.py#L1-L2" target="_blank" rel="noopener noreferrer">`annofilter_junctions.py` (1:2)</a>
+
+
+
+
+
+### Input/Output (I/O) Utility
+
+This component encapsulates the functionalities for reading input files (e.g., BED, GTF) and writing processed data to output files (e.g., annotated BED, filtered BED). It handles file operations and data serialization/deserialization.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/annofilter_junctions.py#L1-L2" target="_blank" rel="noopener noreferrer">`annofilter_junctions.py` (1:2)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,221 @@
+```mermaid
+
+graph LR
+
+    CLI_and_Configuration_Manager["CLI and Configuration Manager"]
+
+    Input_Output_Manager["Input/Output Manager"]
+
+    GTF_Data_Processor["GTF Data Processor"]
+
+    Junction_Data_Processor["Junction Data Processor"]
+
+    Junction_Analysis_Core["Junction Analysis Core"]
+
+    Main_Workflow_Orchestrator["Main Workflow Orchestrator"]
+
+    General_Utilities["General Utilities"]
+
+    CLI_and_Configuration_Manager -- "provides configuration to" --> Main_Workflow_Orchestrator
+
+    Main_Workflow_Orchestrator -- "orchestrates calls to" --> Input_Output_Manager
+
+    Main_Workflow_Orchestrator -- "orchestrates calls to" --> Junction_Analysis_Core
+
+    Input_Output_Manager -- "reads GTF data for" --> GTF_Data_Processor
+
+    Input_Output_Manager -- "reads junction data for" --> Junction_Data_Processor
+
+    Junction_Data_Processor -- "writes processed data from" --> Input_Output_Manager
+
+    GTF_Data_Processor -- "provides structured GTF data to" --> Junction_Analysis_Core
+
+    Junction_Data_Processor -- "provides junction data to" --> Junction_Analysis_Core
+
+    Junction_Analysis_Core -- "updates junction data in" --> Junction_Data_Processor
+
+    General_Utilities -- "used by" --> GTF_Data_Processor
+
+    General_Utilities -- "used by" --> Junction_Data_Processor
+
+    General_Utilities -- "used by" --> Junction_Analysis_Core
+
+    click CLI_and_Configuration_Manager href "https://github.com/pfizer-opensource/annofilter-junctions/blob/main/.codeboarding//CLI_and_Configuration_Manager.md" "Details"
+
+    click GTF_Data_Processor href "https://github.com/pfizer-opensource/annofilter-junctions/blob/main/.codeboarding//GTF_Data_Processor.md" "Details"
+
+    click Junction_Data_Processor href "https://github.com/pfizer-opensource/annofilter-junctions/blob/main/.codeboarding//Junction_Data_Processor.md" "Details"
+
+    click General_Utilities href "https://github.com/pfizer-opensource/annofilter-junctions/blob/main/.codeboarding//General_Utilities.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `annofilter-junctions` project is structured as a modular bioinformatics data processing pipeline, primarily focused on annotating and filtering RNA-seq junctions. The architecture emphasizes clear separation of concerns, with distinct components handling command-line interaction, data input/output, data modeling and parsing, core annotation and filtering logic, and overall workflow orchestration.
+
+
+
+### CLI and Configuration Manager [[Expand]](./CLI_and_Configuration_Manager.md)
+
+Defines, parses, and validates command-line arguments, setting up initial execution parameters and providing validated input to the Main Workflow Orchestrator.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `argparse_logic` (1:1)
+
+
+
+
+
+### Input/Output Manager
+
+Manages all file operations, including reading raw junction data (BED) and GTF annotation files, and writing filtered/annotated output. It acts as the primary interface for data ingress and egress.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `file_reading_writing` (1:1)
+
+- `gtf_file_reading` (1:1)
+
+
+
+
+
+### GTF Data Processor [[Expand]](./GTF_Data_Processor.md)
+
+Defines data structures for genomic features (genes, transcripts, exons) and contains the logic to parse GTF files into these structured models. It provides the necessary transcriptome context for junction annotation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `GtfFeature` (1:1)
+
+- `parse_gtf_attributes` (1:1)
+
+- `parse_gtf_row` (1:1)
+
+
+
+
+
+### Junction Data Processor [[Expand]](./Junction_Data_Processor.md)
+
+Manages the representation of RNA-seq junction data, including genomic coordinates and attributes, and parses BED-formatted junction files. It holds the junction data throughout the annotation and filtering process.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `parse_bed12_row` (1:1)
+
+- `group_bed_by_name` (1:1)
+
+
+
+
+
+### Junction Analysis Core
+
+Implements the core logic for both annotating RNA-seq junctions against transcriptome data (determining known/novel status) and applying various filtering criteria based on user-defined parameters.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `get_junction_info` (1:1)
+
+- `get_ss_info` (1:1)
+
+- `is_known_junction` (1:1)
+
+- `is_known_donor` (1:1)
+
+- `SSOverlap` (1:1)
+
+- `filtering_functions` (1:1)
+
+
+
+
+
+### Main Workflow Orchestrator
+
+Coordinates the overall data processing workflow. It receives configuration, instructs the Input/Output Manager, and orchestrates the sequence of operations involving the Junction Analysis Core.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `main_execution_block` (1:1)
+
+
+
+
+
+### General Utilities [[Expand]](./General_Utilities.md)
+
+Provides common helper functions for tasks such as coordinate calculations, string manipulation, and data formatting, which are reusable across different core components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `get_junction_id` (1:1)
+
+- `get_donor_id` (1:1)
+
+- `get_acceptor_id` (1:1)
+
+- <a href="https://github.com/pfizer-opensource/annofilter-junctions/blob/main/transcriptome.py#L1-L1" target="_blank" rel="noopener noreferrer">`transcriptome.py` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR includes documentation enhanced with Mermaid diagrams that represent the codebase at a high level. You can view how they’re rendered here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/annofilter-junctions/on_boarding.md

The goal of these documents is to help people get up to speed quickly with the annofilter-junctions codebase. Considering that annofilter-junctions is a core component for other projects, I suppose a lot of people interact with it. The diagrams are designed to make codebases more approachable—especially for those who use code as a tool rather than as professional software engineers.

We believe this can be especially helpful in organizations like Pfizer, where many scientists and domain experts write or interact with code to support their work. We'd love to hear if diagrams like these could improve your onboarding or collaboration processes. What does your current onboarding look like? Do you think auto-generated, diagram-first documentation could play a role?

We’re generating these diagrams using a combination of static analysis and LLMs. We’ve also built a GitHub Action that you can add to any repository—it automatically updates the diagrams on every merge to main, release, or based on other heuristics.

We’d really love to connect and learn more about your needs—whether it's around onboarding, documentation, or helping people work more effectively with code. If you’re open to a quick chat, we’d be excited to explore how we can support your team.